### PR TITLE
feat: add admin panel for user management

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -8,16 +8,23 @@
         <a @click="router.push('/temperature')">Temperature</a>
         <a @click="router.push('/alcohol')">Alcohol</a>
         <a @click="router.push('/deviations')">Deviations</a>
-        
-        <a 
-          v-if="authStore.getUserRole === 'MANAGER' || authStore.getUserRole === 'ADMIN'" 
+
+        <a
+          v-if="authStore.getUserRole === 'MANAGER' || authStore.getUserRole === 'ADMIN'"
           @click="router.push('/manage-checklists')"
           style="color: #f1c40f; font-weight: bold;"
         >
           Manage Checklists
         </a>
+        <a
+          v-if="authStore.getUserRole === 'ADMIN'"
+          @click="router.push('/admin')"
+          style="color: #e74c3c; font-weight: bold;"
+        >
+          Admin
+        </a>
       </div>
-      
+
       <div class="nav-right">
         <span class="nav-user">{{ authStore.user?.email }} ({{ authStore.user?.role }})</span>
         <button @click="handleLogout" class="logout-btn">Log out</button>

--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -1,0 +1,16 @@
+import api from '@/api/axios'
+
+export async function getUsers() {
+  const response = await api.get('/admin/users')
+  return response.data
+}
+
+export async function createUser(userData) {
+  const response = await api.post('/admin/users', userData)
+  return response.data
+}
+
+export async function updateUserRole(userId, role) {
+  const response = await api.patch(`/admin/users/${userId}/role`, { role })
+  return response.data
+}

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -81,6 +81,15 @@ const router = createRouter({
         roles: ['EMPLOYEE', 'MANAGER', 'ADMIN'],
       },
     },
+    {
+      path: '/admin',
+      name: 'admin',
+      component: () => import('../views/AdminView.vue'),
+      meta: {
+        requiresAuth: true,
+        roles: ['ADMIN'],
+      },
+    },
     // for later if we want a specific dashboard path pointing to the same place
     {
       path: '/dashboard',
@@ -93,17 +102,15 @@ const router = createRouter({
 router.beforeEach((to, from, next) => {
   const authStore = useAuthStore()
 
-  // check if route demands login trhough meta-field
   const requiresAuth = to.matched.some((record) => record.meta.requiresAuth)
 
   if (requiresAuth && !authStore.isLoggedIn) {
-    // not logged in? send to login!
     next('/login')
   } else if ((to.path === '/login' || to.path === '/register') && authStore.isLoggedIn) {
-    // already logged in, but trying to see login/register -> send to dashboard
+    next('/')
+  } else if (to.meta.roles && !to.meta.roles.includes(authStore.getUserRole)) {
     next('/')
   } else {
-    // logged in or public site? go ahead!
     next()
   }
 })

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,0 +1,315 @@
+<template>
+  <div class="admin-wrapper">
+    <div class="admin-container">
+      <h2>User Management</h2>
+      <p class="subtitle">Admin panel: manage users and roles</p>
+
+      <p v-if="successMessage" class="success-message">{{ successMessage }}</p>
+      <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+      <section class="card">
+        <h3>Create new user</h3>
+        <div class="form-group">
+          <label>E-mail</label>
+          <input v-model="newUser.email" type="email" placeholder="name@bedrift.no" />
+        </div>
+        <div class="form-group">
+          <label>Password</label>
+          <input v-model="newUser.password" type="password" placeholder="At least 8 characters" />
+        </div>
+        <div class="form-group">
+          <label>Role</label>
+          <select v-model="newUser.role">
+            <option value="EMPLOYEE">Employee</option>
+            <option value="MANAGER">Manager</option>
+            <option value="ADMIN">Admin</option>
+          </select>
+        </div>
+        <button @click="handleCreateUser" :disabled="loading">
+          {{ loading ? 'Creating...' : 'Create user' }}
+        </button>
+      </section>
+
+      <section class="card">
+        <h3>All users</h3>
+        <p v-if="users.length === 0" class="empty-state">No users found.</p>
+        <table v-else>
+          <thead>
+          <tr>
+            <th>E-mail</th>
+            <th>Role</th>
+            <th>Change role</th>
+          </tr>
+          </thead>
+          <tbody>
+          <tr v-for="user in users" :key="user.id">
+            <td>{{ user.email }}</td>
+            <td>
+              <span :class="['role-badge', roleBadgeClass(user.role)]">{{ user.role }}</span>
+            </td>
+            <td>
+              <div class="role-change">
+                <select v-model="user.pendingRole">
+                  <option value="EMPLOYEE">Employee</option>
+                  <option value="MANAGER">Manager</option>
+                  <option value="ADMIN">Admin</option>
+                </select>
+                <button
+                  class="btn-save"
+                  @click="handleChangeRole(user)"
+                  :disabled="user.pendingRole === user.role"
+                >
+                  Save
+                </button>
+              </div>
+            </td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { getUsers, createUser, updateUserRole } from '@/api/admin'
+
+const users = ref([])
+const loading = ref(false)
+const successMessage = ref('')
+const errorMessage = ref('')
+
+const newUser = ref({
+  email: '',
+  password: '',
+  role: 'EMPLOYEE',
+})
+
+function showSuccess(msg) {
+  successMessage.value = msg
+  errorMessage.value = ''
+  setTimeout(() => (successMessage.value = ''), 3000)
+}
+
+function showError(msg) {
+  errorMessage.value = msg
+  successMessage.value = ''
+}
+
+function roleBadgeClass(role) {
+  return {
+    ADMIN: 'badge-admin',
+    MANAGER: 'badge-manager',
+    EMPLOYEE: 'badge-employee',
+  }[role] || ''
+}
+
+async function fetchUsers() {
+  try {
+    const data = await getUsers()
+    users.value = data.map((u) => ({ ...u, pendingRole: u.role }))
+  } catch {
+    // fall back to mock data while backend is not ready
+    users.value = mockUsers.map((u) => ({ ...u }))
+  }
+}
+
+async function handleCreateUser() {
+  if (!newUser.value.email || !newUser.value.password) {
+    showError('E-mail and password are required.')
+    return
+  }
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+  if (!emailRegex.test(newUser.value.email)) {
+    showError('Must be a valid e-mail address.')
+    return
+  }
+
+  if (newUser.value.password.length < 8) {
+    showError('Password must be at least 8 characters.')
+    return
+  }
+
+  loading.value = true
+  try {
+    await createUser(newUser.value)
+    showSuccess(`User ${newUser.value.email} created.`)
+    newUser.value = { email: '', password: '', role: 'EMPLOYEE' }
+    await fetchUsers()
+  } catch (err) {
+    const data = err.response?.data
+    const rawMessage = data?.errors?.[0] || data?.error || 'Something went wrong. Try again.'
+    const message = rawMessage.includes(': ') ? rawMessage.split(': ').slice(1).join(': ') : rawMessage
+    showError(message)
+  } finally {
+    loading.value = false
+  }
+}
+
+async function handleChangeRole(user) {
+  try {
+    await updateUserRole(user.id, user.pendingRole)
+    user.role = user.pendingRole
+    showSuccess(`Role updated to ${user.role} for ${user.email}.`)
+  } catch {
+    showError('Could not update role. Try again.')
+  }
+}
+
+onMounted(fetchUsers)
+</script>
+
+<style scoped>
+.admin-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.admin-container {
+  width: 100%;
+  max-width: 800px;
+}
+
+h2 {
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: #666;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+h3 {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  font-weight: bold;
+  color: #2c3e50;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+label {
+  font-weight: bold;
+  font-size: 0.9rem;
+  margin-bottom: 0.3rem;
+}
+
+input,
+select {
+  padding: 0.6rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 1rem;
+}
+
+button {
+  padding: 0.7rem 1.4rem;
+  background-color: #4caf50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  margin-top: 0.5rem;
+}
+
+button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th {
+  text-align: left;
+  padding: 0.6rem 0.8rem;
+  background: #f0f0f0;
+  font-size: 0.85rem;
+  color: #555;
+}
+
+td {
+  padding: 0.7rem 0.8rem;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+  vertical-align: middle;
+}
+
+.role-change {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.role-change select {
+  padding: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.btn-save {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  margin-top: 0;
+}
+
+.role-badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.badge-admin {
+  background: #fdecea;
+  color: #c0392b;
+}
+
+.badge-manager {
+  background: #fff8e1;
+  color: #f39c12;
+}
+
+.badge-employee {
+  background: #e8f5e9;
+  color: #27ae60;
+}
+
+.empty-state {
+  color: #999;
+  font-style: italic;
+}
+
+.success-message {
+  color: #27ae60;
+  background: #e8f5e9;
+  padding: 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+
+.error-message {
+  color: #d32f2f;
+  background: #ffebee;
+  padding: 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+}
+</style>

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
@@ -1,0 +1,55 @@
+package ntnu.no.fs_v26.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import ntnu.no.fs_v26.service.AdminService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "Admin endpoints for user management")
+public class AdminController {
+
+  private final AdminService adminService;
+
+  @Operation(summary = "Get all users", description = "Returns all users. Requires ADMIN role.")
+  @ApiResponse(responseCode = "200", description = "List of users returned successfully")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @GetMapping("/users")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<List<Map<String, Object>>> getAllUsers() {
+    return ResponseEntity.ok(adminService.getAllUsers());
+  }
+
+  @Operation(summary = "Create a new user", description = "Creates a user with email, password and role. Requires ADMIN role.")
+  @ApiResponse(responseCode = "201", description = "User created successfully")
+  @ApiResponse(responseCode = "400", description = "Invalid input or e-mail already in use")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @PostMapping("/users")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Object>> createUser(@Valid @RequestBody AdminCreateUserRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createUser(request));
+  }
+
+  @Operation(summary = "Update user role", description = "Changes the role of a user. Requires ADMIN role.")
+  @ApiResponse(responseCode = "200", description = "Role updated successfully")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @PatchMapping("/users/{userId}/role")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Object>> updateUserRole(
+      @PathVariable Long userId,
+      @RequestBody AdminUpdateRoleRequest request) {
+    return ResponseEntity.ok(adminService.updateUserRole(userId, request));
+  }
+}

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminCreateUserRequest.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminCreateUserRequest.java
@@ -1,0 +1,25 @@
+package ntnu.no.fs_v26.controller;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import ntnu.no.fs_v26.model.Role;
+
+@Data
+public class AdminCreateUserRequest {
+
+  @NotBlank(message = "E-mail is required")
+  @Email(message = "Must be a valid e-mail address")
+  private String email;
+
+  @NotBlank(message = "Password is required")
+  @Size(min = 8, message = "Password must be at least 8 characters")
+  private String password;
+
+  @NotNull(message = "Role is required")
+  private Role role;
+
+  private Long organizationId = 1L;
+}

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminUpdateRoleRequest.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminUpdateRoleRequest.java
@@ -1,0 +1,12 @@
+package ntnu.no.fs_v26.controller;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import ntnu.no.fs_v26.model.Role;
+
+@Data
+public class AdminUpdateRoleRequest {
+
+  @NotNull(message = "Role is required")
+  private Role role;
+}

--- a/src/main/java/ntnu/no/fs_v26/service/AdminService.java
+++ b/src/main/java/ntnu/no/fs_v26/service/AdminService.java
@@ -1,0 +1,71 @@
+package ntnu.no.fs_v26.service;
+
+import lombok.RequiredArgsConstructor;
+import ntnu.no.fs_v26.controller.AdminCreateUserRequest;
+import ntnu.no.fs_v26.controller.AdminUpdateRoleRequest;
+import ntnu.no.fs_v26.model.Organization;
+import ntnu.no.fs_v26.model.User;
+import ntnu.no.fs_v26.repository.OrganizationRepository;
+import ntnu.no.fs_v26.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+  private final UserRepository userRepository;
+  private final OrganizationRepository organizationRepository;
+  private final PasswordEncoder passwordEncoder;
+
+  public List<Map<String, Object>> getAllUsers() {
+    return userRepository.findAll().stream()
+        .map(user -> Map.<String, Object>of(
+            "id", user.getId(),
+            "email", user.getEmail(),
+            "role", user.getRole().name()
+        ))
+        .toList();
+  }
+
+  public Map<String, Object> createUser(AdminCreateUserRequest request) {
+    if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+      throw new IllegalArgumentException("E-mail already in use: " + request.getEmail());
+    }
+
+    Organization organization = organizationRepository.findById(request.getOrganizationId())
+        .orElseThrow(() -> new RuntimeException("Organization not found"));
+
+    User user = User.builder()
+        .email(request.getEmail())
+        .password(passwordEncoder.encode(request.getPassword()))
+        .role(request.getRole())
+        .organization(organization)
+        .build();
+
+    User saved = userRepository.save(user);
+
+    return Map.of(
+        "id", saved.getId(),
+        "email", saved.getEmail(),
+        "role", saved.getRole().name()
+    );
+  }
+
+  public Map<String, Object> updateUserRole(Long userId, AdminUpdateRoleRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new RuntimeException("User not found: " + userId));
+
+    user.setRole(request.getRole());
+    User saved = userRepository.save(user);
+
+    return Map.of(
+        "id", saved.getId(),
+        "email", saved.getEmail(),
+        "role", saved.getRole().name()
+    );
+  }
+}


### PR DESCRIPTION
Closes #52 
Adds an admin panel for user management, only visible for ADMIN users.

Frontend:
* AdminView.vue with a user list and form to create users with email, password and role
* admin.js with API calls for fetching, creating and updating users
* /admin route restricted to ADMIN, navbar link visible only to ADMIN
* Navigation guard updated to check roles

Backend:
* AdminController with GET, POST and PATCH endpoints for user management
* AdminService with logic for fetching, creating and updating roles
* Request classes with validation
* All endpoints secured with @PreAuthorize("hasRole('ADMIN')")