### PR TITLE
Issue 72: Add delete and deactivate user to admin panel

### DIFF
--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -14,3 +14,12 @@ export async function updateUserRole(userId, role) {
   const response = await api.patch(`/admin/users/${userId}/role`, { role })
   return response.data
 }
+
+export async function toggleUserActive(userId, active) {
+  const response = await api.patch(`/admin/users/${userId}/active`, { active })
+  return response.data
+}
+
+export async function deleteUser(userId) {
+  await api.delete(`/admin/users/${userId}`)
+}

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -37,29 +37,46 @@
           <thead>
           <tr>
             <th>E-mail</th>
+            <th>Status</th>
             <th>Role</th>
             <th>Change role</th>
+            <th>Actions</th>
           </tr>
           </thead>
           <tbody>
-          <tr v-for="user in users" :key="user.id">
+          <tr v-for="user in users" :key="user.id" :class="{ 'row-inactive': !user.active }">
             <td>{{ user.email }}</td>
+            <td>
+                <span :class="['status-badge', user.active ? 'badge-active' : 'badge-inactive']">
+                  {{ user.active ? 'Active' : 'Inactive' }}
+                </span>
+            </td>
             <td>
               <span :class="['role-badge', roleBadgeClass(user.role)]">{{ user.role }}</span>
             </td>
             <td>
               <div class="role-change">
-                <select v-model="user.pendingRole">
+                <select v-model="user.pendingRole" :disabled="!user.active">
                   <option value="EMPLOYEE">Employee</option>
                   <option value="MANAGER">Manager</option>
                   <option value="ADMIN">Admin</option>
                 </select>
                 <button
-                  class="btn-save"
-                  @click="handleChangeRole(user)"
-                  :disabled="user.pendingRole === user.role"
+                    class="btn-save"
+                    @click="handleChangeRole(user)"
+                    :disabled="user.pendingRole === user.role || !user.active"
                 >
                   Save
+                </button>
+              </div>
+            </td>
+            <td>
+              <div class="action-buttons">
+                <button class="btn-deactivate" @click="handleToggleActive(user)">
+                  {{ user.active ? 'Deactivate' : 'Activate' }}
+                </button>
+                <button class="btn-delete" @click="handleDeleteUser(user)">
+                  Delete
                 </button>
               </div>
             </td>
@@ -73,7 +90,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getUsers, createUser, updateUserRole } from '@/api/admin'
+import { getUsers, createUser, updateUserRole, deleteUser, toggleUserActive } from '@/api/admin'
 
 const users = ref([])
 const loading = ref(false)
@@ -110,8 +127,7 @@ async function fetchUsers() {
     const data = await getUsers()
     users.value = data.map((u) => ({ ...u, pendingRole: u.role }))
   } catch {
-    // fall back to mock data while backend is not ready
-    users.value = mockUsers.map((u) => ({ ...u }))
+    showError('Could not load users.')
   }
 }
 
@@ -158,6 +174,30 @@ async function handleChangeRole(user) {
   }
 }
 
+async function handleToggleActive(user) {
+  const action = user.active ? 'deactivate' : 'activate'
+  if (!confirm(`Are you sure you want to ${action} ${user.email}?`)) return
+  try {
+    await toggleUserActive(user.id, !user.active)
+    user.active = !user.active
+    showSuccess(`User ${user.email} ${user.active ? 'activated' : 'deactivated'}.`)
+  } catch {
+    showError(`Could not ${action} user. Try again.`)
+  }
+}
+
+async function handleDeleteUser(user) {
+  if (!confirm(`Are you sure you want to permanently delete ${user.email}?`)) return
+  try {
+    await deleteUser(user.id)
+    showSuccess(`User ${user.email} deleted.`)
+    await fetchUsers()
+  } catch (err) {
+    const message = err.response?.data?.error || 'Could not delete user. Try again.'
+    showError(message)
+  }
+}
+
 onMounted(fetchUsers)
 </script>
 
@@ -170,7 +210,7 @@ onMounted(fetchUsers)
 
 .admin-container {
   width: 100%;
-  max-width: 800px;
+  max-width: 900px;
 }
 
 h2 {
@@ -253,6 +293,10 @@ td {
   vertical-align: middle;
 }
 
+.row-inactive {
+  opacity: 0.5;
+}
+
 .role-change {
   display: flex;
   gap: 0.5rem;
@@ -264,10 +308,29 @@ td {
   font-size: 0.9rem;
 }
 
+.action-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
 .btn-save {
   padding: 0.4rem 0.8rem;
   font-size: 0.85rem;
   margin-top: 0;
+}
+
+.btn-deactivate {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  margin-top: 0;
+  background-color: #f39c12;
+}
+
+.btn-delete {
+  padding: 0.4rem 0.8rem;
+  font-size: 0.85rem;
+  margin-top: 0;
+  background-color: #e74c3c;
 }
 
 .role-badge {
@@ -290,6 +353,23 @@ td {
 .badge-employee {
   background: #e8f5e9;
   color: #27ae60;
+}
+
+.status-badge {
+  padding: 0.25rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: bold;
+}
+
+.badge-active {
+  background: #e8f5e9;
+  color: #27ae60;
+}
+
+.badge-inactive {
+  background: #f0f0f0;
+  color: #999;
 }
 
 .empty-state {

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
@@ -52,4 +52,27 @@ public class AdminController {
       @RequestBody AdminUpdateRoleRequest request) {
     return ResponseEntity.ok(adminService.updateUserRole(userId, request));
   }
+
+  @Operation(summary = "Toggle user active status", description = "Activates or deactivates a user. Requires ADMIN role.")
+  @ApiResponse(responseCode = "200", description = "Status updated successfully")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @PatchMapping("/users/{userId}/active")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Object>> toggleUserActive(
+      @PathVariable Long userId,
+      @RequestBody AdminToggleActiveRequest request) {
+    return ResponseEntity.ok(adminService.toggleUserActive(userId, request));
+  }
+
+  @Operation(summary = "Delete a user", description = "Deletes a user by ID. Requires ADMIN role.")
+  @ApiResponse(responseCode = "204", description = "User deleted successfully")
+  @ApiResponse(responseCode = "404", description = "User not found")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @DeleteMapping("/users/{userId}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Void> deleteUser(@PathVariable Long userId) {
+    adminService.deleteUser(userId);
+    return ResponseEntity.noContent().build();
+  }
 }

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminToggleActiveRequest.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminToggleActiveRequest.java
@@ -1,0 +1,7 @@
+package ntnu.no.fs_v26.controller;
+
+import lombok.Data;
+@Data
+public class AdminToggleActiveRequest {
+  private boolean active;
+}

--- a/src/main/java/ntnu/no/fs_v26/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ntnu/no/fs_v26/exception/GlobalExceptionHandler.java
@@ -85,4 +85,22 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.badRequest().body(body);
     }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(ResourceNotFoundException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 404);
+        body.put("error", ex.getMessage());
+        body.put("timestamp", LocalDateTime.now().toString());
+        return ResponseEntity.status(404).body(body);
+    }
+
+    @ExceptionHandler(ResourceConflictException.class)
+    public ResponseEntity<Map<String, Object>> handleConflict(ResourceConflictException ex) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("status", 409);
+        body.put("error", ex.getMessage());
+        body.put("timestamp", LocalDateTime.now().toString());
+        return ResponseEntity.status(409).body(body);
+    }
 }

--- a/src/main/java/ntnu/no/fs_v26/exception/ResourceConflictException.java
+++ b/src/main/java/ntnu/no/fs_v26/exception/ResourceConflictException.java
@@ -1,0 +1,7 @@
+package ntnu.no.fs_v26.exception;
+
+public class ResourceConflictException extends RuntimeException {
+  public ResourceConflictException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/ntnu/no/fs_v26/exception/ResourceNotFoundException.java
+++ b/src/main/java/ntnu/no/fs_v26/exception/ResourceNotFoundException.java
@@ -1,0 +1,7 @@
+package ntnu.no.fs_v26.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/ntnu/no/fs_v26/model/User.java
+++ b/src/main/java/ntnu/no/fs_v26/model/User.java
@@ -36,9 +36,13 @@ public class User implements UserDetails {
   @Column(nullable = false)
   private Role role;
 
+  @Column(nullable = false)
+  @Builder.Default
+  private boolean active = true;
+
   @ManyToOne
-  @JoinColumn(name = "organization_id", nullable = true) // make this true now
-  @com.fasterxml.jackson.annotation.JsonIgnore // stops infinite loop
+  @JoinColumn(name = "organization_id", nullable = true)
+  @com.fasterxml.jackson.annotation.JsonIgnore
   private Organization organization;
 
   @Column(name = "created_at")
@@ -51,7 +55,6 @@ public class User implements UserDetails {
 
   @Override
   public Collection<? extends GrantedAuthority> getAuthorities() {
-    // make the enum-role to an authority Spring understands (f.eks "ROLE_ADMIN")
     return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
   }
 
@@ -77,7 +80,7 @@ public class User implements UserDetails {
 
   @Override
   public boolean isEnabled() {
-    return true;
+    return active;
   }
 
   @Override

--- a/src/main/java/ntnu/no/fs_v26/repository/AlcoholLogRepository.java
+++ b/src/main/java/ntnu/no/fs_v26/repository/AlcoholLogRepository.java
@@ -1,6 +1,7 @@
 package ntnu.no.fs_v26.repository;
 
 import ntnu.no.fs_v26.model.AlcoholLog;
+import ntnu.no.fs_v26.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -22,4 +23,6 @@ public interface AlcoholLogRepository extends JpaRepository<AlcoholLog, Long> {
     List<AlcoholLog> findByOrganizationIdAndShiftDateOrderByRecordedAtDesc(
             Long organizationId,
             LocalDate shiftDate);
+
+    boolean existsByRecordedBy(User user);
 }

--- a/src/main/java/ntnu/no/fs_v26/repository/ChecklistItemRepository.java
+++ b/src/main/java/ntnu/no/fs_v26/repository/ChecklistItemRepository.java
@@ -1,9 +1,11 @@
 package ntnu.no.fs_v26.repository;
 
 import ntnu.no.fs_v26.model.ChecklistItem;
+import ntnu.no.fs_v26.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChecklistItemRepository extends JpaRepository<ChecklistItem, Long> {
+  boolean existsByCompletedBy(User user);
 }

--- a/src/main/java/ntnu/no/fs_v26/repository/DeviationRepository.java
+++ b/src/main/java/ntnu/no/fs_v26/repository/DeviationRepository.java
@@ -1,6 +1,7 @@
 package ntnu.no.fs_v26.repository;
 
 import ntnu.no.fs_v26.model.Deviation;
+import ntnu.no.fs_v26.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 @Repository
 public interface DeviationRepository extends JpaRepository<Deviation, Long> {
     List<Deviation> findAllByOrganizationId(Long organizationId);
+    boolean existsByReportedBy(User user);
 }

--- a/src/main/java/ntnu/no/fs_v26/repository/TemperatureLogRepository.java
+++ b/src/main/java/ntnu/no/fs_v26/repository/TemperatureLogRepository.java
@@ -1,6 +1,7 @@
 package ntnu.no.fs_v26.repository;
 
 import ntnu.no.fs_v26.model.TemperatureLog;
+import ntnu.no.fs_v26.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -22,4 +23,6 @@ public interface TemperatureLogRepository extends JpaRepository<TemperatureLog, 
             Long organizationId,
             LocalDateTime start,
             LocalDateTime end);
+
+    boolean existsByLoggedBy(User user);
 }

--- a/src/main/java/ntnu/no/fs_v26/service/AdminService.java
+++ b/src/main/java/ntnu/no/fs_v26/service/AdminService.java
@@ -2,10 +2,17 @@ package ntnu.no.fs_v26.service;
 
 import lombok.RequiredArgsConstructor;
 import ntnu.no.fs_v26.controller.AdminCreateUserRequest;
+import ntnu.no.fs_v26.controller.AdminToggleActiveRequest;
 import ntnu.no.fs_v26.controller.AdminUpdateRoleRequest;
+import ntnu.no.fs_v26.exception.ResourceConflictException;
+import ntnu.no.fs_v26.exception.ResourceNotFoundException;
 import ntnu.no.fs_v26.model.Organization;
 import ntnu.no.fs_v26.model.User;
+import ntnu.no.fs_v26.repository.AlcoholLogRepository;
+import ntnu.no.fs_v26.repository.ChecklistItemRepository;
+import ntnu.no.fs_v26.repository.DeviationRepository;
 import ntnu.no.fs_v26.repository.OrganizationRepository;
+import ntnu.no.fs_v26.repository.TemperatureLogRepository;
 import ntnu.no.fs_v26.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,13 +27,18 @@ public class AdminService {
   private final UserRepository userRepository;
   private final OrganizationRepository organizationRepository;
   private final PasswordEncoder passwordEncoder;
+  private final ChecklistItemRepository checklistItemRepository;
+  private final TemperatureLogRepository temperatureLogRepository;
+  private final DeviationRepository deviationRepository;
+  private final AlcoholLogRepository alcoholLogRepository;
 
   public List<Map<String, Object>> getAllUsers() {
     return userRepository.findAll().stream()
         .map(user -> Map.<String, Object>of(
             "id", user.getId(),
             "email", user.getEmail(),
-            "role", user.getRole().name()
+            "role", user.getRole().name(),
+            "active", user.isActive()
         ))
         .toList();
   }
@@ -37,13 +49,14 @@ public class AdminService {
     }
 
     Organization organization = organizationRepository.findById(request.getOrganizationId())
-        .orElseThrow(() -> new RuntimeException("Organization not found"));
+        .orElseThrow(() -> new ResourceNotFoundException("Organization not found"));
 
     User user = User.builder()
         .email(request.getEmail())
         .password(passwordEncoder.encode(request.getPassword()))
         .role(request.getRole())
         .organization(organization)
+        .active(true)
         .build();
 
     User saved = userRepository.save(user);
@@ -51,13 +64,14 @@ public class AdminService {
     return Map.of(
         "id", saved.getId(),
         "email", saved.getEmail(),
-        "role", saved.getRole().name()
+        "role", saved.getRole().name(),
+        "active", saved.isActive()
     );
   }
 
   public Map<String, Object> updateUserRole(Long userId, AdminUpdateRoleRequest request) {
     User user = userRepository.findById(userId)
-        .orElseThrow(() -> new RuntimeException("User not found: " + userId));
+        .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
 
     user.setRole(request.getRole());
     User saved = userRepository.save(user);
@@ -65,7 +79,42 @@ public class AdminService {
     return Map.of(
         "id", saved.getId(),
         "email", saved.getEmail(),
-        "role", saved.getRole().name()
+        "role", saved.getRole().name(),
+        "active", saved.isActive()
     );
+  }
+
+  public Map<String, Object> toggleUserActive(Long userId, AdminToggleActiveRequest request) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+
+    user.setActive(request.isActive());
+    User saved = userRepository.save(user);
+
+    return Map.of(
+        "id", saved.getId(),
+        "email", saved.getEmail(),
+        "role", saved.getRole().name(),
+        "active", saved.isActive()
+    );
+  }
+
+  public void deleteUser(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+
+    boolean hasReferences =
+        checklistItemRepository.existsByCompletedBy(user) ||
+            temperatureLogRepository.existsByLoggedBy(user) ||
+            deviationRepository.existsByReportedBy(user) ||
+            alcoholLogRepository.existsByRecordedBy(user);
+
+    if (hasReferences) {
+      throw new ResourceConflictException(
+          "User cannot be deleted because they have existing logs or deviations. Deactivate the user instead."
+      );
+    }
+
+    userRepository.delete(user);
   }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -11,8 +11,9 @@ CREATE TABLE IF NOT EXISTS users (
     role VARCHAR(50) NOT NULL,
     organization_id BIGINT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
     FOREIGN KEY (organization_id) REFERENCES organizations(id)
-);
+    );
 
 CREATE TABLE IF NOT EXISTS checklists (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
Closes #72 
Adds deactivate and delete functionality to the admin panel.

* Admins can deactivate/activate users. Deactivated users cannot log in
* Admins can delete users, but only if they have no existing logs or deviations
* Deleting a user with references returns 409 with a clear error message
* Added active column to the users table