### PR TITLE
fix: enforce multi-tenancy using organization from JWT

### DIFF
--- a/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
@@ -5,10 +5,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import ntnu.no.fs_v26.model.User;
 import ntnu.no.fs_v26.service.AdminService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -27,8 +29,9 @@ public class AdminController {
   @ApiResponse(responseCode = "403", description = "Access denied")
   @GetMapping("/users")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<List<Map<String, Object>>> getAllUsers() {
-    return ResponseEntity.ok(adminService.getAllUsers());
+  public ResponseEntity<List<Map<String, Object>>> getAllUsers(
+      @AuthenticationPrincipal User currentUser) {
+    return ResponseEntity.ok(adminService.getAllUsers(currentUser));
   }
 
   @Operation(summary = "Create a new user", description = "Creates a user with email, password and role. Requires ADMIN role.")
@@ -37,8 +40,10 @@ public class AdminController {
   @ApiResponse(responseCode = "403", description = "Access denied")
   @PostMapping("/users")
   @PreAuthorize("hasRole('ADMIN')")
-  public ResponseEntity<Map<String, Object>> createUser(@Valid @RequestBody AdminCreateUserRequest request) {
-    return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createUser(request));
+  public ResponseEntity<Map<String, Object>> createUser(
+      @Valid @RequestBody AdminCreateUserRequest request,
+      @AuthenticationPrincipal User currentUser) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createUser(request, currentUser));
   }
 
   @Operation(summary = "Update user role", description = "Changes the role of a user. Requires ADMIN role.")

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminCreateUserRequest.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminCreateUserRequest.java
@@ -20,6 +20,4 @@ public class AdminCreateUserRequest {
 
   @NotNull(message = "Role is required")
   private Role role;
-
-  private Long organizationId = 1L;
 }

--- a/src/main/java/ntnu/no/fs_v26/repository/UserRepository.java
+++ b/src/main/java/ntnu/no/fs_v26/repository/UserRepository.java
@@ -11,6 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   List<User> findByOrganizationAndRole(Organization organization, Role role);
-
   List<User> findByOrganizationAndRoleIn(Organization organization, List<Role> roles);
+  List<User> findByOrganization(Organization organization);
 }

--- a/src/main/java/ntnu/no/fs_v26/service/AdminService.java
+++ b/src/main/java/ntnu/no/fs_v26/service/AdminService.java
@@ -6,7 +6,6 @@ import ntnu.no.fs_v26.controller.AdminToggleActiveRequest;
 import ntnu.no.fs_v26.controller.AdminUpdateRoleRequest;
 import ntnu.no.fs_v26.exception.ResourceConflictException;
 import ntnu.no.fs_v26.exception.ResourceNotFoundException;
-import ntnu.no.fs_v26.model.Organization;
 import ntnu.no.fs_v26.model.User;
 import ntnu.no.fs_v26.repository.AlcoholLogRepository;
 import ntnu.no.fs_v26.repository.ChecklistItemRepository;
@@ -32,82 +31,86 @@ public class AdminService {
     private final DeviationRepository deviationRepository;
     private final AlcoholLogRepository alcoholLogRepository;
 
-    public List<Map<String, Object>> getAllUsers() {
-        return userRepository.findAll().stream()
-                .map(user -> Map.<String, Object>of(
-                        "id", user.getId(),
-                        "email", user.getEmail(),
-                        "role", user.getRole().name(),
-                        "active", user.isActive()))
-                .toList();
+    public List<Map<String, Object>> getAllUsers(User currentUser) {
+        return userRepository.findByOrganization(currentUser.getOrganization()).stream()
+            .map(user -> Map.<String, Object>of(
+                "id", user.getId(),
+                "email", user.getEmail(),
+                "role", user.getRole().name(),
+                "active", user.isActive()))
+            .toList();
     }
 
-    public Map<String, Object> createUser(AdminCreateUserRequest request) {
+    /**
+     * Creates a new user in the same organization as the authenticated admin.
+     * The organization is always taken from the admin's JWT, never from the request body.
+     *
+     * @param request     the user details to create
+     * @param currentUser the authenticated admin performing the action
+     * @return a map with the created user's details
+     */
+    public Map<String, Object> createUser(AdminCreateUserRequest request, User currentUser) {
         if (userRepository.findByEmail(request.getEmail()).isPresent()) {
             throw new ResourceConflictException("E-mail already in use: " + request.getEmail());
         }
 
-        Organization organization = organizationRepository.findById(request.getOrganizationId())
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        "Organization not found: " + request.getOrganizationId()));
-
         User user = User.builder()
-                .email(request.getEmail())
-                .password(passwordEncoder.encode(request.getPassword()))
-                .role(request.getRole())
-                .organization(organization)
-                .active(true)
-                .build();
+            .email(request.getEmail())
+            .password(passwordEncoder.encode(request.getPassword()))
+            .role(request.getRole())
+            .organization(currentUser.getOrganization())
+            .active(true)
+            .build();
 
         User saved = userRepository.save(user);
 
         return Map.of(
-                "id", saved.getId(),
-                "email", saved.getEmail(),
-                "role", saved.getRole().name(),
-                "active", saved.isActive());
+            "id", saved.getId(),
+            "email", saved.getEmail(),
+            "role", saved.getRole().name(),
+            "active", saved.isActive());
     }
 
     public Map<String, Object> updateUserRole(Long userId, AdminUpdateRoleRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+            .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
 
         user.setRole(request.getRole());
         User saved = userRepository.save(user);
 
         return Map.of(
-                "id", saved.getId(),
-                "email", saved.getEmail(),
-                "role", saved.getRole().name(),
-                "active", saved.isActive());
+            "id", saved.getId(),
+            "email", saved.getEmail(),
+            "role", saved.getRole().name(),
+            "active", saved.isActive());
     }
 
     public Map<String, Object> toggleUserActive(Long userId, AdminToggleActiveRequest request) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+            .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
 
         user.setActive(request.isActive());
         User saved = userRepository.save(user);
 
         return Map.of(
-                "id", saved.getId(),
-                "email", saved.getEmail(),
-                "role", saved.getRole().name(),
-                "active", saved.isActive());
+            "id", saved.getId(),
+            "email", saved.getEmail(),
+            "role", saved.getRole().name(),
+            "active", saved.isActive());
     }
 
     public void deleteUser(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+            .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
 
         boolean hasReferences = checklistItemRepository.existsByCompletedBy(user)
-                || temperatureLogRepository.existsByLoggedBy(user)
-                || deviationRepository.existsByReportedBy(user)
-                || alcoholLogRepository.existsByRecordedBy(user);
+            || temperatureLogRepository.existsByLoggedBy(user)
+            || deviationRepository.existsByReportedBy(user)
+            || alcoholLogRepository.existsByRecordedBy(user);
 
         if (hasReferences) {
             throw new ResourceConflictException(
-                    "User cannot be deleted because they have existing logs or deviations. Deactivate the user instead.");
+                "User cannot be deleted because they have existing logs or deviations. Deactivate the user instead.");
         }
 
         userRepository.delete(user);

--- a/src/main/java/ntnu/no/fs_v26/service/DeviationService.java
+++ b/src/main/java/ntnu/no/fs_v26/service/DeviationService.java
@@ -70,7 +70,7 @@ public class DeviationService {
 
         // Security: verify deviation belongs to the user's organization
         if (!deviation.getOrganization().getId().equals(user.getOrganization().getId())) {
-            throw new IllegalArgumentException("Access denied: deviation belongs to a different organization");
+            throw new org.springframework.security.access.AccessDeniedException("Access denied: deviation belongs to a different organization");
         }
 
         deviation.setStatus(newStatus);

--- a/src/test/java/ntnu/no/fs_v26/controller/MultiTenancyIT.java
+++ b/src/test/java/ntnu/no/fs_v26/controller/MultiTenancyIT.java
@@ -1,0 +1,303 @@
+package ntnu.no.fs_v26.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import ntnu.no.fs_v26.model.*;
+import ntnu.no.fs_v26.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import ntnu.no.fs_v26.model.TrainingCompletionType;
+import ntnu.no.fs_v26.model.TrainingDocument;
+import ntnu.no.fs_v26.model.TrainingDocumentType;
+import ntnu.no.fs_v26.repository.TrainingDocumentRepository;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Transactional
+class MultiTenancyIT {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private OrganizationRepository orgRepository;
+
+  @Autowired
+  private UserRepository userRepository;
+
+  @Autowired
+  private DeviationRepository deviationRepository;
+
+  @Autowired
+  private ChecklistRepository checklistRepository;
+
+  @Autowired
+  private EquipmentRepository equipmentRepository;
+
+  @Autowired
+  private TemperatureLogRepository temperatureLogRepository;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  private User userOrgA;
+  private User userOrgB;
+  private Organization orgA;
+  private Organization orgB;
+
+  @BeforeEach
+  void setUp() {
+    orgA = orgRepository.save(Organization.builder().name("Restaurant A").build());
+    orgB = orgRepository.save(Organization.builder().name("Restaurant B").build());
+
+    userOrgA = userRepository.save(User.builder()
+        .email("employee@orgA.no")
+        .password("pw")
+        .role(Role.EMPLOYEE)
+        .organization(orgA)
+        .build());
+
+    userOrgB = userRepository.save(User.builder()
+        .email("employee@orgB.no")
+        .password("pw")
+        .role(Role.EMPLOYEE)
+        .organization(orgB)
+        .build());
+
+    // Data for orgA
+    deviationRepository.save(Deviation.builder()
+        .title("Deviation in org A")
+        .status(DeviationStatus.OPEN)
+        .module(DeviationModule.IK_MAT)
+        .createdAt(LocalDateTime.now())
+        .organization(orgA)
+        .reportedBy(userOrgA)
+        .build());
+
+    checklistRepository.save(Checklist.builder()
+        .title("Checklist in org A")
+        .organization(orgA)
+        .build());
+
+    // Data for orgB
+    deviationRepository.save(Deviation.builder()
+        .title("Deviation in org B")
+        .status(DeviationStatus.OPEN)
+        .module(DeviationModule.IK_MAT)
+        .createdAt(LocalDateTime.now())
+        .organization(orgB)
+        .reportedBy(userOrgB)
+        .build());
+
+    checklistRepository.save(Checklist.builder()
+        .title("Checklist in org B")
+        .organization(orgB)
+        .build());
+  }
+
+  // ── Deviations ────────────────────────────────────────────────────────────
+
+  @Test
+  void deviations_userFromOrgA_shouldOnlySeeOrgAData() throws Exception {
+    mockMvc.perform(get("/api/v1/deviations")
+            .with(user(userOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].title", is("Deviation in org A")));
+  }
+
+  @Test
+  void deviations_userFromOrgB_shouldOnlySeeOrgBData() throws Exception {
+    mockMvc.perform(get("/api/v1/deviations")
+            .with(user(userOrgB)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].title", is("Deviation in org B")));
+  }
+
+  @Test
+  void deviations_managerFromOrgB_cannotUpdateStatusOfOrgADeviation() throws Exception {
+    Deviation orgADeviation = deviationRepository
+        .findAllByOrganizationId(orgA.getId()).get(0);
+
+    User managerOrgB = userRepository.save(User.builder()
+        .email("manager@orgB.no")
+        .password("pw")
+        .role(Role.MANAGER)
+        .organization(orgB)
+        .build());
+
+    mockMvc.perform(patch("/api/v1/deviations/" + orgADeviation.getId() + "/status")
+            .param("status", "RESOLVED")
+            .with(user(managerOrgB)))
+        .andExpect(status().isForbidden());
+  }
+
+  // ── Checklists ────────────────────────────────────────────────────────────
+
+  @Test
+  void checklists_userFromOrgA_shouldOnlySeeOrgAData() throws Exception {
+    mockMvc.perform(get("/api/v1/checklists")
+            .with(user(userOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].title", is("Checklist in org A")));
+  }
+
+  @Test
+  void checklists_userFromOrgB_shouldOnlySeeOrgBData() throws Exception {
+    mockMvc.perform(get("/api/v1/checklists")
+            .with(user(userOrgB)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].title", is("Checklist in org B")));
+  }
+
+  // ── Temperature logs ──────────────────────────────────────────────────────
+
+  @Test
+  void temperatureLogs_userFromOrgA_shouldOnlySeeOrgAData() throws Exception {
+    Equipment equipA = equipmentRepository.save(Equipment.builder()
+        .name("Fridge A")
+        .minTemp(0).maxTemp(4)
+        .organization(orgA)
+        .build());
+
+    temperatureLogRepository.save(TemperatureLog.builder()
+        .value(3.0)
+        .timestamp(LocalDateTime.now())
+        .isDeviation(false)
+        .equipment(equipA)
+        .loggedBy(userOrgA)
+        .build());
+
+    mockMvc.perform(get("/api/v1/temperature-logs")
+            .with(user(userOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)));
+  }
+
+  // ── Training documents ────────────────────────────────────────────────────
+
+  @Autowired
+  private TrainingDocumentRepository trainingDocumentRepository;
+
+  @Test
+  void trainingPolicies_userFromOrgA_shouldOnlySeeOrgADocuments() throws Exception {
+    trainingDocumentRepository.save(TrainingDocument.builder()
+        .title("Policy in org A")
+        .content("content")
+        .type(TrainingDocumentType.POLICY)
+        .completionType(TrainingCompletionType.READ_ACKNOWLEDGE)
+        .organization(orgA)
+        .active(true)
+        .build());
+
+    trainingDocumentRepository.save(TrainingDocument.builder()
+        .title("Policy in org B")
+        .content("content")
+        .type(TrainingDocumentType.POLICY)
+        .completionType(TrainingCompletionType.READ_ACKNOWLEDGE)
+        .organization(orgB)
+        .active(true)
+        .build());
+
+    mockMvc.perform(get("/api/v1/training/policies")
+            .with(user(userOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].title", is("Policy in org A")));
+  }
+
+  // ── Admin ─────────────────────────────────────────────────────────────────
+
+  @Test
+  void admin_createUser_organizationTakenFromJwt_notFromBody() throws Exception {
+    User adminOrgA = userRepository.save(User.builder()
+        .email("admin@orgA.no")
+        .password("pw")
+        .role(Role.ADMIN)
+        .organization(orgA)
+        .build());
+
+    Map<String, Object> body = Map.of(
+        "email", "newuser@test.no",
+        "password", "Password1",
+        "role", "EMPLOYEE"
+    );
+
+    mockMvc.perform(post("/api/v1/admin/users")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(body))
+            .with(user(adminOrgA)))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.email", is("newuser@test.no")));
+
+    // Verify new user belongs to orgA
+    User newUser = userRepository.findByEmail("newuser@test.no").orElseThrow();
+    org.junit.jupiter.api.Assertions.assertEquals(orgA.getId(), newUser.getOrganization().getId());
+  }
+
+  @Test
+  void admin_getAllUsers_shouldOnlySeeUsersFromOwnOrganization() throws Exception {
+    User adminOrgA = userRepository.save(User.builder()
+        .email("admin@orgA.no")
+        .password("pw")
+        .role(Role.ADMIN)
+        .organization(orgA)
+        .build());
+
+    mockMvc.perform(get("/api/v1/admin/users")
+            .with(user(adminOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[*].email", not(hasItem("employee@orgB.no"))));
+  }
+
+  // ── organizationId must never be accepted from request body ───────────────
+
+  @Test
+  void deviations_requestBodyOrganizationIdIsIgnored_savedUnderAuthenticatedUsersOrg() throws Exception {
+    Map<String, Object> body = Map.of(
+        "title", "Sneaky deviation",
+        "description", "Trying to assign to org B",
+        "module", "IK_MAT",
+        "organizationId", orgB.getId()
+    );
+
+    mockMvc.perform(post("/api/v1/deviations")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(body))
+            .with(user(userOrgA)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.organization.name", is("Restaurant A")));
+  }
+
+  // ── Unauthenticated access ────────────────────────────────────────────────
+
+  @Test
+  void deviations_withoutAuthentication_shouldReturn403() throws Exception {
+    mockMvc.perform(get("/api/v1/deviations"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  void checklists_withoutAuthentication_shouldReturn403() throws Exception {
+    mockMvc.perform(get("/api/v1/checklists"))
+        .andExpect(status().isForbidden());
+  }
+}


### PR DESCRIPTION
Closes #49 

* Ensures users can only access data from their own organization. 
* Organization is always taken from the JWT, never from the request body. 
* Cross-organization access returns 403 Forbidden.
* Added integration tests verifying data isolation across organizations, 403 on cross-org access, and that organizationId in request body is ignored.