### PR TITLE
Add organization management and seed data for multi tenancy demo

### DIFF
--- a/frontend/src/api/admin.js
+++ b/frontend/src/api/admin.js
@@ -23,3 +23,8 @@ export async function toggleUserActive(userId, active) {
 export async function deleteUser(userId) {
   await api.delete(`/admin/users/${userId}`)
 }
+
+export async function createOrganization(data) {
+  const response = await api.post('/admin/organizations', data)
+  return response.data
+}

--- a/frontend/src/views/AdminView.vue
+++ b/frontend/src/views/AdminView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="admin-wrapper">
     <div class="admin-container">
-      <h1>User Management</h1>
-      <p class="subtitle">Admin panel: manage users and roles</p>
+      <h1>Administration</h1>
+      <p class="subtitle">Manage users and organizations</p>
 
       <p v-if="successMessage" class="success-message" role="status" aria-live="polite">
         <span aria-hidden="true">✓ </span>{{ successMessage }}
@@ -11,8 +11,55 @@
         <span aria-hidden="true">⚠ </span>{{ errorMessage }}
       </p>
 
+      <!-- Create new organization -->
+      <section class="card" aria-labelledby="create-org-heading">
+        <h2 id="create-org-heading">Create new organization</h2>
+
+        <div class="form-group">
+          <label for="org-name">Organization name</label>
+          <input
+            id="org-name"
+            v-model="newOrg.organizationName"
+            type="text"
+            placeholder="Restaurant name"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="org-admin-email">Admin e-mail</label>
+          <input
+            id="org-admin-email"
+            v-model="newOrg.adminEmail"
+            type="email"
+            placeholder="admin@restaurant.no"
+            autocomplete="email"
+          />
+        </div>
+
+        <div class="form-group">
+          <label for="org-admin-password">Admin password</label>
+          <input
+            id="org-admin-password"
+            v-model="newOrg.adminPassword"
+            type="password"
+            placeholder="At least 8 characters"
+            autocomplete="new-password"
+          />
+          <ul class="password-requirements">
+            <li :class="{ met: newOrg.adminPassword.length >= 8 }">At least 8 characters</li>
+            <li :class="{ met: /[A-Z]/.test(newOrg.adminPassword) }">At least one uppercase letter</li>
+            <li :class="{ met: /[0-9]/.test(newOrg.adminPassword) }">At least one number</li>
+          </ul>
+        </div>
+
+        <button class="primary-btn" @click="handleCreateOrganization" :disabled="orgLoading">
+          {{ orgLoading ? 'Creating...' : 'Create organization' }}
+        </button>
+      </section>
+
+      <!-- Create new user -->
       <section class="card" aria-labelledby="create-user-heading">
-        <h2 id="create-user-heading">Create new user</h2>
+        <h2 id="create-user-heading">Create new user in {{ orgName }}</h2>
 
         <div class="form-group">
           <label for="new-user-email">E-mail</label>
@@ -22,8 +69,6 @@
             type="email"
             placeholder="name@bedrift.no"
             autocomplete="email"
-            :aria-invalid="!!errorMessage"
-            :aria-describedby="errorMessage ? 'admin-form-error' : undefined"
           />
         </div>
 
@@ -35,7 +80,7 @@
             type="password"
             placeholder="At least 8 characters"
             autocomplete="new-password"
-            :aria-describedby="'password-rules'"
+            aria-describedby="password-rules"
           />
           <ul id="password-rules" class="password-requirements">
             <li :class="{ met: newUser.password.length >= 8 }">At least 8 characters</li>
@@ -52,14 +97,10 @@
             type="password"
             placeholder="Repeat your password"
             autocomplete="new-password"
-            :aria-invalid="!!(newUser.confirmPassword && newUser.password !== newUser.confirmPassword)"
-            :aria-describedby="newUser.confirmPassword && newUser.password !== newUser.confirmPassword ? 'confirm-password-error' : undefined"
           />
           <p
             v-if="newUser.confirmPassword && newUser.password !== newUser.confirmPassword"
-            id="confirm-password-error"
             class="field-error"
-            role="alert"
           >
             Passwords do not match.
           </p>
@@ -74,76 +115,71 @@
           </select>
         </div>
 
-        <button @click="handleCreateUser" :disabled="loading" class="primary-btn">
+        <button class="primary-btn" @click="handleCreateUser" :disabled="loading">
           {{ loading ? 'Creating...' : 'Create user' }}
         </button>
-
-        <p v-if="errorMessage" id="admin-form-error" class="sr-only">
-          {{ errorMessage }}
-        </p>
       </section>
 
+      <!-- All users -->
       <section class="card" aria-labelledby="all-users-heading">
         <h2 id="all-users-heading">All users</h2>
         <p v-if="users.length === 0" class="empty-state">No users found.</p>
-
         <div v-else class="table-wrapper">
           <table>
-            <caption class="sr-only">List of users with status, role, role change and actions</caption>
             <thead>
-              <tr>
-                <th scope="col">E-mail</th>
-                <th scope="col">Status</th>
-                <th scope="col">Role</th>
-                <th scope="col">Change role</th>
-                <th scope="col">Actions</th>
-              </tr>
+            <tr>
+              <th scope="col">E-mail</th>
+              <th scope="col">Status</th>
+              <th scope="col">Role</th>
+              <th scope="col">Change role</th>
+              <th scope="col">Actions</th>
+            </tr>
             </thead>
             <tbody>
-              <tr v-for="user in users" :key="user.id" :class="{ 'row-inactive': !user.active }">
-                <td data-label="E-mail">{{ user.email }}</td>
-                <td data-label="Status">
+            <tr v-for="user in users" :key="user.id" :class="{ 'row-inactive': !user.active }">
+              <td data-label="E-mail">{{ user.email }}</td>
+              <td data-label="Status">
                   <span :class="['status-badge', user.active ? 'badge-active' : 'badge-inactive']">
                     {{ user.active ? 'Active' : 'Inactive' }}
                   </span>
-                </td>
-                <td data-label="Role">
+              </td>
+              <td data-label="Role">
                   <span :class="['role-badge', roleBadgeClass(user.role)]">
                     {{ user.role }}
                   </span>
-                </td>
-                <td data-label="Change role">
-                  <div class="role-change">
-                    <label class="sr-only" :for="`role-${user.id}`">Change role for {{ user.email }}</label>
-                    <select
-                      :id="`role-${user.id}`"
-                      v-model="user.pendingRole"
-                      :disabled="!user.active"
-                    >
-                      <option value="EMPLOYEE">Employee</option>
-                      <option value="MANAGER">Manager</option>
-                      <option value="ADMIN">Admin</option>
-                    </select>
-                    <button
-                      class="btn-save"
-                      @click="handleChangeRole(user)"
-                      :disabled="user.pendingRole === user.role || !user.active"
-                    >
-                      Save
-                    </button>
-                  </div>
-                </td>
-                <td data-label="Actions">
-                  <div class="action-buttons">
-                    <button class="btn-deactivate" @click="handleToggleActive(user)">
-                      {{ user.active ? 'Deactivate' : 'Activate' }}
-                    </button>
-                    <button class="btn-delete" @click="handleDeleteUser(user)">
-                      Delete
-                    </button>
-                  </div>
-                </td>
-              </tr>
+              </td>
+              <td data-label="Change role">
+                <div class="role-change">
+                  <label class="sr-only" :for="`role-${user.id}`">Change role for {{ user.email }}</label>
+                  <select
+                    :id="`role-${user.id}`"
+                    v-model="user.pendingRole"
+                    :disabled="!user.active"
+                  >
+                    <option value="EMPLOYEE">Employee</option>
+                    <option value="MANAGER">Manager</option>
+                    <option value="ADMIN">Admin</option>
+                  </select>
+                  <button
+                    class="btn-save"
+                    @click="handleChangeRole(user)"
+                    :disabled="user.pendingRole === user.role || !user.active"
+                  >
+                    Save
+                  </button>
+                </div>
+              </td>
+              <td data-label="Actions">
+                <div class="action-buttons">
+                  <button class="btn-deactivate" @click="handleToggleActive(user)">
+                    {{ user.active ? 'Deactivate' : 'Activate' }}
+                  </button>
+                  <button class="btn-delete" @click="handleDeleteUser(user)">
+                    Delete
+                  </button>
+                </div>
+              </td>
+            </tr>
             </tbody>
           </table>
         </div>
@@ -154,10 +190,14 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import { getUsers, createUser, updateUserRole, deleteUser, toggleUserActive } from '@/api/admin'
+import { useAuthStore } from '@/stores/auth'
+const authStore = useAuthStore()
+const orgName = authStore.user?.organization?.name || 'your organization'
+import { getUsers, createUser, updateUserRole, deleteUser, toggleUserActive, createOrganization } from '@/api/admin'
 
 const users = ref([])
 const loading = ref(false)
+const orgLoading = ref(false)
 const successMessage = ref('')
 const errorMessage = ref('')
 
@@ -168,10 +208,16 @@ const newUser = ref({
   role: 'EMPLOYEE',
 })
 
+const newOrg = ref({
+  organizationName: '',
+  adminEmail: '',
+  adminPassword: '',
+})
+
 function showSuccess(msg) {
   successMessage.value = msg
   errorMessage.value = ''
-  setTimeout(() => (successMessage.value = ''), 3000)
+  setTimeout(() => (successMessage.value = ''), 4000)
 }
 
 function showError(msg) {
@@ -200,6 +246,37 @@ async function fetchUsers() {
     users.value = data.map((u) => ({ ...u, pendingRole: u.role }))
   } catch {
     showError('Could not load users.')
+  }
+}
+
+async function handleCreateOrganization() {
+  if (!newOrg.value.organizationName || !newOrg.value.adminEmail || !newOrg.value.adminPassword) {
+    showError('All fields are required.')
+    return
+  }
+
+  const passwordError = validatePassword(newOrg.value.adminPassword)
+  if (passwordError) {
+    showError(passwordError)
+    return
+  }
+
+  orgLoading.value = true
+  try {
+    const result = await createOrganization({
+      organizationName: newOrg.value.organizationName,
+      adminEmail: newOrg.value.adminEmail,
+      adminPassword: newOrg.value.adminPassword,
+    })
+    showSuccess(`Organization "${result.organizationName}" created. Admin: ${result.adminEmail}`)
+    newOrg.value = { organizationName: '', adminEmail: '', adminPassword: '' }
+  } catch (err) {
+    const data = err.response?.data
+    const rawMessage = data?.errors?.[0] || data?.error || 'Something went wrong. Try again.'
+    const message = rawMessage.includes(': ') ? rawMessage.split(': ').slice(1).join(': ') : rawMessage
+    showError(message)
+  } finally {
+    orgLoading.value = false
   }
 }
 
@@ -322,13 +399,6 @@ h2 {
   border: 1px solid #e0dfd8;
   padding: 1.5rem;
   margin-bottom: 1.5rem;
-}
-
-h3 {
-  margin-bottom: 1rem;
-  font-size: 1rem;
-  font-weight: bold;
-  color: #2c3e50;
 }
 
 .form-group {
@@ -498,37 +568,13 @@ th {
   border: 0;
 }
 
-.btn-save {
-  background: #6b7280;
-}
-
-.btn-deactivate {
-  background-color: #d97706;
-}
-
-.btn-delete {
-  background-color: #dc2626;
-}
-
-.badge-admin {
-  background: #fdecea;
-  color: #b91c1c;
-}
-
-.badge-manager {
-  background: #fff7db;
-  color: #b45309;
-}
-
-.badge-employee {
-  background: #e8f5e9;
-  color: #166534;
-}
-
-.badge-active {
-  background: #e8f5e9;
-  color: #166534;
-}
+.btn-save { background: #6b7280; }
+.btn-deactivate { background-color: #d97706; }
+.btn-delete { background-color: #dc2626; }
+.badge-admin { background: #fdecea; color: #b91c1c; }
+.badge-manager { background: #fff7db; color: #b45309; }
+.badge-employee { background: #e8f5e9; color: #166534; }
+.badge-active { background: #e8f5e9; color: #166534; }
 
 .success-message {
   color: #166534;
@@ -565,42 +611,15 @@ td {
   outline-offset: 2px;
 }
 
-.btn-save:hover {
-  background: #4b5563;
-}
-
-.btn-deactivate:hover {
-  background: #b45309;
-}
-
-.btn-delete:hover {
-  background: #b91c1c;
-}
+.btn-save:hover { background: #4b5563; }
+.btn-deactivate:hover { background: #b45309; }
+.btn-delete:hover { background: #b91c1c; }
 
 @media (max-width: 768px) {
-  .admin-wrapper {
-    padding: 1rem 0.75rem;
-  }
-
-  .card {
-    padding: 1rem;
-  }
-
-  .action-buttons,
-  .role-change {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .btn-save,
-  .btn-deactivate,
-  .btn-delete {
-    width: 100%;
-  }
-
-  .role-change select {
-    width: 100%;
-    min-width: 0;
-  }
+  .admin-wrapper { padding: 1rem 0.75rem; }
+  .card { padding: 1rem; }
+  .action-buttons, .role-change { flex-direction: column; align-items: stretch; }
+  .btn-save, .btn-deactivate, .btn-delete { width: 100%; }
+  .role-change select { width: 100%; min-width: 0; }
 }
 </style>

--- a/src/main/java/ntnu/no/fs_v26/config/DataInitializer.java
+++ b/src/main/java/ntnu/no/fs_v26/config/DataInitializer.java
@@ -23,72 +23,69 @@ public class DataInitializer implements CommandLineRunner {
                 if (userRepository.count() > 0)
                         return;
 
-                // create organization
-                Organization org = Organization.builder()
-                                .name("Testrestaurant AS")
-                                .build();
-                org = orgRepository.save(org);
-
-                // create users
                 String pw = passwordEncoder.encode("password123");
-                userRepository.save(User.builder().email("admin@test.no").password(pw).role(Role.ADMIN)
-                                .organization(org).build());
-                userRepository.save(User.builder().email("manager@test.no").password(pw).role(Role.MANAGER)
-                                .organization(org).build());
-                userRepository.save(User.builder().email("employee@test.no").password(pw).role(Role.EMPLOYEE)
-                                .organization(org).build());
 
-                // create equipment
-                equipmentRepository.save(Equipment.builder()
-                                .name("Kitchen Fridge")
-                                .minTemp(0)
-                                .maxTemp(4)
-                                .organization(org)
-                                .build());
+                // ── Organization 1: Testrestaurant AS ────────────────────────────────────
+                Organization org1 = orgRepository.save(Organization.builder()
+                    .name("Testrestaurant AS")
+                    .build());
+
+                userRepository.save(User.builder().email("admin@test.no").password(pw)
+                    .role(Role.ADMIN).organization(org1).build());
+                userRepository.save(User.builder().email("manager@test.no").password(pw)
+                    .role(Role.MANAGER).organization(org1).build());
+                userRepository.save(User.builder().email("employee@test.no").password(pw)
+                    .role(Role.EMPLOYEE).organization(org1).build());
 
                 equipmentRepository.save(Equipment.builder()
-                                .name("Cold Storage Fridge")
-                                .minTemp(0)
-                                .maxTemp(4)
-                                .organization(org)
-                                .build());
-
+                    .name("Kitchen Fridge").minTemp(0).maxTemp(4).organization(org1).build());
                 equipmentRepository.save(Equipment.builder()
-                                .name("Freezer Room")
-                                .minTemp(-25)
-                                .maxTemp(-18)
-                                .organization(org)
-                                .build());
-
+                    .name("Cold Storage Fridge").minTemp(0).maxTemp(4).organization(org1).build());
                 equipmentRepository.save(Equipment.builder()
-                                .name("Hot Holding Unit")
-                                .minTemp(60)
-                                .maxTemp(90)
-                                .organization(org)
-                                .build());
+                    .name("Freezer Room").minTemp(-25).maxTemp(-18).organization(org1).build());
+                equipmentRepository.save(Equipment.builder()
+                    .name("Hot Holding Unit").minTemp(60).maxTemp(90).organization(org1).build());
 
-                // create checklist
-                Checklist checklist = Checklist.builder()
-                                .title("Morningroutine Kitchen")
-                                .description("Daily tasks before opening")
-                                .frequency(Frequency.DAILY)
-                                .module(ModuleType.KITCHEN)
-                                .organization(org)
-                                .build();
-                checklist = checklistRepository.save(checklist);
-
-                // create checklist items
+                Checklist checklist1 = checklistRepository.save(Checklist.builder()
+                    .title("Morningroutine Kitchen")
+                    .description("Daily tasks before opening")
+                    .frequency(Frequency.DAILY)
+                    .module(ModuleType.KITCHEN)
+                    .organization(org1)
+                    .build());
                 itemRepository.save(ChecklistItem.builder()
-                                .description("Check temperature in fridge")
-                                .completed(false)
-                                .checklist(checklist)
-                                .build());
-
+                    .description("Check temperature in fridge").completed(false).checklist(checklist1).build());
                 itemRepository.save(ChecklistItem.builder()
-                                .description("Turn on coffeemachine")
-                                .completed(false)
-                                .checklist(checklist)
-                                .build());
+                    .description("Turn on coffeemachine").completed(false).checklist(checklist1).build());
+
+                // ── Organization 2: Testrestaurant 2 AS ──────────────────────────────────
+                Organization org2 = orgRepository.save(Organization.builder()
+                    .name("Testrestaurant 2 AS")
+                    .build());
+
+                userRepository.save(User.builder().email("admin@test2.no").password(pw)
+                    .role(Role.ADMIN).organization(org2).build());
+                userRepository.save(User.builder().email("manager@test2.no").password(pw)
+                    .role(Role.MANAGER).organization(org2).build());
+                userRepository.save(User.builder().email("employee@test2.no").password(pw)
+                    .role(Role.EMPLOYEE).organization(org2).build());
+
+                equipmentRepository.save(Equipment.builder()
+                    .name("Kitchen Fridge").minTemp(0).maxTemp(4).organization(org2).build());
+                equipmentRepository.save(Equipment.builder()
+                    .name("Freezer Room").minTemp(-25).maxTemp(-18).organization(org2).build());
+
+                Checklist checklist2 = checklistRepository.save(Checklist.builder()
+                    .title("Evening Routine Bar")
+                    .description("Daily tasks before closing")
+                    .frequency(Frequency.DAILY)
+                    .module(ModuleType.BAR)
+                    .organization(org2)
+                    .build());
+                itemRepository.save(ChecklistItem.builder()
+                    .description("Check temperature in fridge").completed(false).checklist(checklist2).build());
+                itemRepository.save(ChecklistItem.builder()
+                    .description("Turn on coffeemachine").completed(false).checklist(checklist2).build());
 
                 System.out.println("DEBUG: All test data (users, equipment, and checklists) has been added!");
         }

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminController.java
@@ -24,7 +24,7 @@ public class AdminController {
 
   private final AdminService adminService;
 
-  @Operation(summary = "Get all users", description = "Returns all users. Requires ADMIN role.")
+  @Operation(summary = "Get all users", description = "Returns all users in the admin's organization. Requires ADMIN role.")
   @ApiResponse(responseCode = "200", description = "List of users returned successfully")
   @ApiResponse(responseCode = "403", description = "Access denied")
   @GetMapping("/users")
@@ -34,7 +34,7 @@ public class AdminController {
     return ResponseEntity.ok(adminService.getAllUsers(currentUser));
   }
 
-  @Operation(summary = "Create a new user", description = "Creates a user with email, password and role. Requires ADMIN role.")
+  @Operation(summary = "Create a new user", description = "Creates a user in the admin's organization. Requires ADMIN role.")
   @ApiResponse(responseCode = "201", description = "User created successfully")
   @ApiResponse(responseCode = "400", description = "Invalid input or e-mail already in use")
   @ApiResponse(responseCode = "403", description = "Access denied")
@@ -79,5 +79,17 @@ public class AdminController {
   public ResponseEntity<Void> deleteUser(@PathVariable Long userId) {
     adminService.deleteUser(userId);
     return ResponseEntity.noContent().build();
+  }
+
+  @Operation(summary = "Create a new organization with an admin user",
+      description = "Creates a new organization and an admin user for it. Requires ADMIN role.")
+  @ApiResponse(responseCode = "201", description = "Organization created successfully")
+  @ApiResponse(responseCode = "400", description = "Invalid input or e-mail already in use")
+  @ApiResponse(responseCode = "403", description = "Access denied")
+  @PostMapping("/organizations")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<Map<String, Object>> createOrganization(
+      @Valid @RequestBody AdminCreateOrganizationRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED).body(adminService.createOrganization(request));
   }
 }

--- a/src/main/java/ntnu/no/fs_v26/controller/AdminCreateOrganizationRequest.java
+++ b/src/main/java/ntnu/no/fs_v26/controller/AdminCreateOrganizationRequest.java
@@ -1,0 +1,21 @@
+package ntnu.no.fs_v26.controller;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+@Data
+public class AdminCreateOrganizationRequest {
+
+  @NotBlank(message = "Organization name is required")
+  private String organizationName;
+
+  @NotBlank(message = "Admin e-mail is required")
+  @Email(message = "Must be a valid e-mail address")
+  private String adminEmail;
+
+  @NotBlank(message = "Admin password is required")
+  @Size(min = 8, message = "Password must be at least 8 characters")
+  private String adminPassword;
+}

--- a/src/main/java/ntnu/no/fs_v26/service/AdminService.java
+++ b/src/main/java/ntnu/no/fs_v26/service/AdminService.java
@@ -1,11 +1,14 @@
 package ntnu.no.fs_v26.service;
 
 import lombok.RequiredArgsConstructor;
+import ntnu.no.fs_v26.controller.AdminCreateOrganizationRequest;
 import ntnu.no.fs_v26.controller.AdminCreateUserRequest;
 import ntnu.no.fs_v26.controller.AdminToggleActiveRequest;
 import ntnu.no.fs_v26.controller.AdminUpdateRoleRequest;
 import ntnu.no.fs_v26.exception.ResourceConflictException;
 import ntnu.no.fs_v26.exception.ResourceNotFoundException;
+import ntnu.no.fs_v26.model.Organization;
+import ntnu.no.fs_v26.model.Role;
 import ntnu.no.fs_v26.model.User;
 import ntnu.no.fs_v26.repository.AlcoholLogRepository;
 import ntnu.no.fs_v26.repository.ChecklistItemRepository;
@@ -15,6 +18,7 @@ import ntnu.no.fs_v26.repository.TemperatureLogRepository;
 import ntnu.no.fs_v26.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -71,9 +75,53 @@ public class AdminService {
             "active", saved.isActive());
     }
 
+    /**
+     * Creates a new organization and an admin user for it.
+     *
+     * @param request contains organization name, admin email and admin password
+     * @return a map with the created organization and admin user details
+     */
+    @Transactional
+    public Map<String, Object> createOrganization(AdminCreateOrganizationRequest request) {
+        if (userRepository.findByEmail(request.getAdminEmail()).isPresent()) {
+            throw new ResourceConflictException("E-mail already in use: " + request.getAdminEmail());
+        }
+
+        Organization organization = organizationRepository.save(
+            Organization.builder()
+                .name(request.getOrganizationName())
+                .build());
+
+        User admin = userRepository.save(User.builder()
+            .email(request.getAdminEmail())
+            .password(passwordEncoder.encode(request.getAdminPassword()))
+            .role(Role.ADMIN)
+            .organization(organization)
+            .active(true)
+            .build());
+
+        return Map.of(
+            "organizationId", organization.getId(),
+            "organizationName", organization.getName(),
+            "adminEmail", admin.getEmail(),
+            "adminRole", admin.getRole().name());
+    }
+
     public Map<String, Object> updateUserRole(Long userId, AdminUpdateRoleRequest request) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new ResourceNotFoundException("User not found: " + userId));
+
+        // Prevent downgrading the last admin in the organization
+        if (user.getRole() == Role.ADMIN && request.getRole() != Role.ADMIN) {
+            long adminCount = userRepository.findByOrganization(user.getOrganization())
+                .stream()
+                .filter(u -> u.getRole() == Role.ADMIN && u.isActive())
+                .count();
+            if (adminCount <= 1) {
+                throw new ResourceConflictException(
+                    "Cannot change role of the last admin in the organization.");
+            }
+        }
 
         user.setRole(request.getRole());
         User saved = userRepository.save(user);


### PR DESCRIPTION
Completes multi-tenancy enforcement and adds tooling to demonstrate it in the UI. Organization is always taken from the JWT, never from the request body. Adds a second organization to seed data and a new admin feature for creating organizations with an admin user directly from the admin panel.
